### PR TITLE
autoplaySpeed prop type changed to bool/number

### DIFF
--- a/components/OwlCarousel.jsx
+++ b/components/OwlCarousel.jsx
@@ -305,7 +305,10 @@ OwlCarousel.propTypes = {
 		autoplay: PropTypes.bool,
 		autoplayTimeout: PropTypes.number,
 		autoplayHoverPause: PropTypes.bool,
-		autoplaySpeed: PropTypes.bool,
+		autoplaySpeed: PropTypes.oneOfType([
+			PropTypes.bool,
+			PropTypes.number,
+		]),
 
 		// navigation
 		nav: PropTypes.bool,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19954042/45410490-43436600-b68b-11e8-873d-74b556380240.png)
from https://owlcarousel2.github.io/OwlCarousel2/docs/api-options.html